### PR TITLE
feat : declare states for agents, collection, nft

### DIFF
--- a/cmds/flags.go
+++ b/cmds/flags.go
@@ -37,7 +37,7 @@ type NFTIDFlag struct {
 func (v *NFTIDFlag) UnmarshalText(b []byte) error {
 	l := strings.SplitN(string(b), ",", 2)
 	if len(l) != 2 {
-		return fmt.Errorf("invalid nft id, %q", string(b))
+		return fmt.Errorf("invalid nft id; %q", string(b))
 	}
 
 	s, id := l[0], l[1]
@@ -49,7 +49,7 @@ func (v *NFTIDFlag) UnmarshalText(b []byte) error {
 	v.collection = symbol
 
 	if idx, err := currency.NewBigFromString(id); err != nil {
-		return errors.Wrapf(err, "invalid big string, %q", string(b))
+		return errors.Wrapf(err, "invalid big string; %q", string(b))
 	} else if err := idx.IsValid(nil); err != nil {
 		return err
 	} else {

--- a/cmds/transfer.go
+++ b/cmds/transfer.go
@@ -16,18 +16,16 @@ type TransferCommand struct {
 	OperationFlags
 	Sender   AddressFlag                 `arg:"" name:"sender" help:"sender address; nft owner or agent" required:"true"`
 	Currency currencycmds.CurrencyIDFlag `arg:"" name:"currency" help:"currency id" required:"true"`
-	From     AddressFlag                 `arg:"" name:"from" help:"nft owner" required:"true"`
-	To       AddressFlag                 `arg:"" name:"to" help:"nft receiver" required:"true"`
+	Receiver AddressFlag                 `arg:"" name:"receiver" help:"nft owner" required:"true"`
 	NFTs     []NFTIDFlag                 `arg:"" name:"nft" help:"target nft; \"<symbol>,<idx>\""`
 	sender   base.Address
-	from     base.Address
-	to       base.Address
+	receiver base.Address
 	nfts     []nft.NFTID
 }
 
 func NewTransferCommand() TransferCommand {
 	return TransferCommand{
-		BaseCommand: NewBaseCommand("transfer-operation"),
+		BaseCommand: NewBaseCommand("transfer-nfts-operation"),
 	}
 }
 
@@ -69,16 +67,10 @@ func (cmd *TransferCommand) parseFlags() error {
 		cmd.sender = a
 	}
 
-	if a, err := cmd.From.Encode(jenc); err != nil {
-		return errors.Wrapf(err, "invalid from format; %q", cmd.From.String())
+	if a, err := cmd.Receiver.Encode(jenc); err != nil {
+		return errors.Wrapf(err, "invalid receiver format; %q", cmd.Receiver.String())
 	} else {
-		cmd.from = a
-	}
-
-	if a, err := cmd.To.Encode(jenc); err != nil {
-		return errors.Wrapf(err, "invalid to format; %q", cmd.To.String())
-	} else {
-		cmd.to = a
+		cmd.receiver = a
 	}
 
 	if len(cmd.NFTs) < 1 {
@@ -103,9 +95,9 @@ func (cmd *TransferCommand) createOperation() (operation.Operation, error) {
 	items := make([]collection.TransferItem, 1)
 
 	if len(cmd.nfts) > 1 {
-		items[0] = collection.NewTransferItemMultiNFTs(cmd.from, cmd.to, cmd.nfts, cmd.Currency.CID)
+		items[0] = collection.NewTransferItemMultiNFTs(cmd.receiver, cmd.nfts, cmd.Currency.CID)
 	} else {
-		items[0] = collection.NewTransferItemSingleNFT(cmd.from, cmd.to, cmd.nfts[0], cmd.Currency.CID)
+		items[0] = collection.NewTransferItemSingleNFT(cmd.receiver, cmd.nfts[0], cmd.Currency.CID)
 	}
 
 	fact := collection.NewTransferFact(

--- a/nft/collection/agent_box.go
+++ b/nft/collection/agent_box.go
@@ -89,7 +89,7 @@ func (abx *AgentBox) Sort(ascending bool) {
 }
 
 func (abx AgentBox) Exists(ag base.Address) bool {
-	if len(abx.agents) < 1 {
+	if abx.IsEmpty() {
 		return false
 	}
 	for i := range abx.agents {
@@ -116,6 +116,10 @@ func (abx *AgentBox) Append(ag base.Address) error {
 	if abx.Exists(ag) {
 		return errors.Errorf("agent %v already exists in agent box", ag)
 	}
+	if len(abx.agents) >= MaxAgents {
+		return errors.Errorf("Max agents; %v", ag)
+	}
+
 	abx.agents = append(abx.agents, ag)
 	return nil
 }

--- a/nft/collection/agent_box.go
+++ b/nft/collection/agent_box.go
@@ -1,0 +1,211 @@
+package collection
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/spikeekips/mitum-currency/currency"
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+	bsonenc "github.com/spikeekips/mitum/util/encoder/bson"
+	jsonenc "github.com/spikeekips/mitum/util/encoder/json"
+	"github.com/spikeekips/mitum/util/hint"
+	"github.com/spikeekips/mitum/util/valuehash"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+var (
+	AgentBoxType   = hint.Type("mitum-nft-agent-box")
+	AgentBoxHint   = hint.NewHint(AgentBoxType, "v0.0.1")
+	AgentBoxHinter = AgentBox{BaseHinter: hint.NewBaseHinter(AgentBoxHint)}
+)
+
+type AgentBox struct {
+	hint.BaseHinter
+	agents []base.Address
+}
+
+func NewAgentBox(agents []base.Address) AgentBox {
+	if agents == nil {
+		return AgentBox{agents: []base.Address{}}
+	}
+	return AgentBox{agents: agents}
+}
+
+func (abx AgentBox) Bytes() []byte {
+	bs := make([][]byte, len(abx.agents))
+	for i := range abx.agents {
+		bs[i] = abx.agents[i].Bytes()
+	}
+
+	return util.ConcatBytesSlice(bs...)
+}
+
+func (abx AgentBox) Hint() hint.Hint {
+	return AgentBoxHint
+}
+
+func (abx AgentBox) Hash() valuehash.Hash {
+	return abx.GenerateHash()
+}
+
+func (abx AgentBox) GenerateHash() valuehash.Hash {
+	return valuehash.NewSHA256(abx.Bytes())
+}
+
+func (abx AgentBox) IsEmpty() bool {
+	return len(abx.agents) < 1
+}
+
+func (abx AgentBox) IsValid([]byte) error {
+	for i := range abx.agents {
+		if err := abx.agents[i].IsValid(nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (abx AgentBox) Equal(b AgentBox) bool {
+	abx.Sort(true)
+	b.Sort(true)
+	for i := range abx.agents {
+		if !abx.agents[i].Equal(b.agents[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (abx *AgentBox) Sort(ascending bool) {
+	sort.Slice(abx.agents, func(i, j int) bool {
+		if ascending {
+			return bytes.Compare(abx.agents[j].Bytes(), abx.agents[i].Bytes()) > 0
+		}
+		return bytes.Compare(abx.agents[j].Bytes(), abx.agents[i].Bytes()) < 0
+	})
+}
+
+func (abx AgentBox) Exists(ag base.Address) bool {
+	if len(abx.agents) < 1 {
+		return false
+	}
+	for i := range abx.agents {
+		if ag.Equal(abx.agents[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func (abx AgentBox) Get(ag base.Address) (base.Address, error) {
+	for i := range abx.agents {
+		if ag.Equal(abx.agents[i]) {
+			return abx.agents[i], nil
+		}
+	}
+	return currency.Address{}, errors.Errorf("agent not found in owner's agent box; %v", ag)
+}
+
+func (abx *AgentBox) Append(ag base.Address) error {
+	if err := ag.IsValid(nil); err != nil {
+		return err
+	}
+	if abx.Exists(ag) {
+		return errors.Errorf("agent %v already exists in agent box", ag)
+	}
+	abx.agents = append(abx.agents, ag)
+	return nil
+}
+
+func (abx *AgentBox) Remove(ag base.Address) error {
+	if !abx.Exists(ag) {
+		return errors.Errorf("agent %v not found in agent box", ag)
+	}
+	for i := range abx.agents {
+		if ag.String() == abx.agents[i].String() {
+			abx.agents[i] = abx.agents[len(abx.agents)-1]
+			abx.agents[len(abx.agents)-1] = currency.Address{}
+			abx.agents = abx.agents[:len(abx.agents)-1]
+			return nil
+		}
+	}
+	return nil
+}
+
+func (abx AgentBox) Agents() []base.Address {
+	return abx.agents
+}
+
+type AgentBoxJSONPacker struct {
+	jsonenc.HintedHead
+	AG []base.Address `json:"agents"`
+}
+
+func (abx AgentBox) MarshalJSON() ([]byte, error) {
+	return jsonenc.Marshal(AgentBoxJSONPacker{
+		HintedHead: jsonenc.NewHintedHead(abx.Hint()),
+		AG:         abx.agents,
+	})
+}
+
+type AgentBoxJSONUnpacker struct {
+	AG []base.AddressDecoder `json:"agents"`
+}
+
+func (abx *AgentBox) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {
+	var uag AgentBoxJSONUnpacker
+	if err := enc.Unmarshal(b, &uag); err != nil {
+		return err
+	}
+
+	return abx.unpack(enc, uag.AG)
+}
+
+type AgentBoxBSONPacker struct {
+	AG []base.Address `bson:"agents"`
+}
+
+func (abx AgentBox) MarshalBSON() ([]byte, error) {
+	return bsonenc.Marshal(bsonenc.MergeBSONM(
+		bsonenc.NewHintedDoc(abx.Hint()),
+		bson.M{
+			"agents": abx.agents,
+		}),
+	)
+}
+
+type AgentBoxBSONUnpacker struct {
+	AG []base.AddressDecoder `bson:"agents"`
+}
+
+func (abx *AgentBox) UnpackBSON(b []byte, enc *bsonenc.Encoder) error {
+	var uag AgentBoxBSONUnpacker
+	if err := bsonenc.Unmarshal(b, &uag); err != nil {
+		return err
+	}
+
+	return abx.unpack(enc, uag.AG)
+}
+
+func (abx *AgentBox) unpack(
+	enc encoder.Encoder,
+	bAgents []base.AddressDecoder, // base.Addresss
+) error {
+
+	agents := make([]base.Address, len(bAgents))
+	for i := range agents {
+		agent, err := bAgents[i].Encode(enc)
+		if err != nil {
+			return err
+		}
+
+		agents[i] = agent
+	}
+
+	abx.agents = agents
+
+	return nil
+}

--- a/nft/collection/collection.go
+++ b/nft/collection/collection.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 
 	"github.com/ProtoconNet/mitum-nft/nft"
-	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum-currency/currency"
 	"github.com/spikeekips/mitum/util"
 	"github.com/spikeekips/mitum/util/hint"
 	"github.com/spikeekips/mitum/util/isvalid"
@@ -47,23 +47,23 @@ var (
 type Policy struct {
 	hint.BaseHinter
 	name    CollectionName
-	creator base.Address
 	royalty nft.PaymentParameter
 	uri     url.URL
+	limit   currency.Big
 }
 
-func NewPolicy(name CollectionName, creator base.Address, royalty nft.PaymentParameter, uri url.URL) Policy {
+func NewPolicy(name CollectionName, royalty nft.PaymentParameter, uri url.URL, limit currency.Big) Policy {
 	return Policy{
 		BaseHinter: hint.NewBaseHinter(PolicyHint),
 		name:       name,
-		creator:    creator,
 		royalty:    royalty,
 		uri:        uri,
+		limit:      limit,
 	}
 }
 
-func MustNewPolicy(name CollectionName, creator base.Address, royalty nft.PaymentParameter, uri url.URL) Policy {
-	policy := NewPolicy(name, creator, royalty, uri)
+func MustNewPolicy(name CollectionName, royalty nft.PaymentParameter, uri url.URL, limit currency.Big) Policy {
+	policy := NewPolicy(name, royalty, uri, limit)
 
 	if err := policy.IsValid(nil); err != nil {
 		panic(err)
@@ -75,17 +75,17 @@ func MustNewPolicy(name CollectionName, creator base.Address, royalty nft.Paymen
 func (policy Policy) Bytes() []byte {
 	return util.ConcatBytesSlice(
 		policy.name.Bytes(),
-		policy.creator.Bytes(),
 		policy.royalty.Bytes(),
 		[]byte(policy.uri.String()),
+		policy.limit.Bytes(),
 	)
 }
 
 func (policy Policy) IsValid([]byte) error {
 	if err := isvalid.Check(nil, false,
 		policy.name,
-		policy.creator,
-		policy.royalty); err != nil {
+		policy.royalty,
+		policy.limit); err != nil {
 		return err
 	}
 
@@ -96,16 +96,16 @@ func (policy Policy) Name() CollectionName {
 	return policy.name
 }
 
-func (policy Policy) Creator() base.Address {
-	return policy.creator
-}
-
 func (policy Policy) Royalty() nft.PaymentParameter {
 	return policy.royalty
 }
 
 func (policy Policy) Uri() url.URL {
 	return policy.uri
+}
+
+func (policy Policy) Limit() currency.Big {
+	return policy.limit
 }
 
 func (policy Policy) Rebuild() nft.BasePolicy {

--- a/nft/collection/collection_bson.go
+++ b/nft/collection/collection_bson.go
@@ -3,7 +3,6 @@ package collection
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/spikeekips/mitum/base"
 	bsonenc "github.com/spikeekips/mitum/util/encoder/bson"
 )
 
@@ -12,25 +11,25 @@ func (p Policy) MarshalBSON() ([]byte, error) {
 		bsonenc.NewHintedDoc(p.Hint()),
 		bson.M{
 			"name":    p.name,
-			"creator": p.creator,
 			"royalty": p.royalty,
 			"uri":     p.uri.String(),
+			"limit":   p.limit.String(),
 		},
 	))
 }
 
-type CollectionPolicyBSONUnpacker struct {
-	NM string              `bson:"name"`
-	CE base.AddressDecoder `bson:"creator"`
-	RY uint                `bson:"royalty"`
-	UR string              `bson:"uri"`
+type PolicyBSONUnpacker struct {
+	NM string `bson:"name"`
+	RY uint   `bson:"royalty"`
+	UR string `bson:"uri"`
+	LI string `bson:"limit"`
 }
 
 func (p Policy) UnpackBSON(b []byte, enc *bsonenc.Encoder) error {
-	var ucp CollectionPolicyBSONUnpacker
-	if err := enc.Unmarshal(b, &ucp); err != nil {
+	var up PolicyBSONUnpacker
+	if err := enc.Unmarshal(b, &up); err != nil {
 		return err
 	}
 
-	return p.unpack(enc, ucp.NM, ucp.CE, ucp.RY, ucp.UR)
+	return p.unpack(enc, up.NM, up.RY, up.UR, up.LI)
 }

--- a/nft/collection/collection_encode.go
+++ b/nft/collection/collection_encode.go
@@ -5,24 +5,18 @@ import (
 
 	"github.com/ProtoconNet/mitum-nft/nft"
 
-	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum-currency/currency"
 	"github.com/spikeekips/mitum/util/encoder"
 )
 
 func (p *Policy) unpack(
 	enc encoder.Encoder,
 	name string,
-	bCreator base.AddressDecoder,
 	royalty uint,
 	_uri string,
+	_limit string,
 ) error {
 	p.name = CollectionName(name)
-
-	creator, err := bCreator.Encode(enc)
-	if err != nil {
-		return err
-	}
-	p.creator = creator
 
 	p.royalty = nft.PaymentParameter(royalty)
 
@@ -30,6 +24,12 @@ func (p *Policy) unpack(
 		return err
 	} else {
 		p.uri = *uri
+	}
+
+	if limit, err := currency.NewBigFromString(_limit); err != nil {
+		return err
+	} else {
+		p.limit = limit
 	}
 
 	return nil

--- a/nft/collection/collection_json.go
+++ b/nft/collection/collection_json.go
@@ -3,33 +3,33 @@ package collection
 import (
 	"github.com/ProtoconNet/mitum-nft/nft"
 
-	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum-currency/currency"
 	jsonenc "github.com/spikeekips/mitum/util/encoder/json"
 )
 
 type PolicyJSONPacker struct {
 	jsonenc.HintedHead
 	NM CollectionName       `json:"name"`
-	CE base.Address         `json:"creator"`
 	RY nft.PaymentParameter `json:"royalty"`
 	UR string               `json:"uri"`
+	LI currency.Big         `json:"limit"`
 }
 
 func (p Policy) MarshalJSON() ([]byte, error) {
 	return jsonenc.Marshal(PolicyJSONPacker{
 		HintedHead: jsonenc.NewHintedHead(p.Hint()),
 		NM:         p.name,
-		CE:         p.creator,
 		RY:         p.royalty,
 		UR:         p.uri.String(),
+		LI:         p.limit,
 	})
 }
 
 type PolicyJSONUnpacker struct {
-	NM string              `json:"name"`
-	CE base.AddressDecoder `json:"creator"`
-	RY uint                `json:"royalty"`
-	UR string              `json:"uri"`
+	NM string `json:"name"`
+	RY uint   `json:"royalty"`
+	UR string `json:"uri"`
+	LI string `json:"limit"`
 }
 
 func (p *Policy) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {
@@ -38,5 +38,5 @@ func (p *Policy) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {
 		return err
 	}
 
-	return p.unpack(enc, up.NM, up.CE, up.RY, up.UR)
+	return p.unpack(enc, up.NM, up.RY, up.UR, up.LI)
 }

--- a/nft/collection/collection_register.go
+++ b/nft/collection/collection_register.go
@@ -24,17 +24,15 @@ type CollectionRegisterFact struct {
 	h      valuehash.Hash
 	token  []byte
 	sender base.Address
-	target base.Address
 	design nft.Design
 	cid    currency.CurrencyID
 }
 
-func NewCollectionRegisterFact(token []byte, sender base.Address, target base.Address, design nft.Design, cid currency.CurrencyID) CollectionRegisterFact {
+func NewCollectionRegisterFact(token []byte, sender base.Address, design nft.Design, cid currency.CurrencyID) CollectionRegisterFact {
 	fact := CollectionRegisterFact{
 		BaseHinter: hint.NewBaseHinter(CollectionRegisterFactHint),
 		token:      token,
 		sender:     sender,
-		target:     target,
 		design:     design,
 		cid:        cid,
 	}
@@ -55,7 +53,6 @@ func (fact CollectionRegisterFact) Bytes() []byte {
 	return util.ConcatBytesSlice(
 		fact.token,
 		fact.sender.Bytes(),
-		fact.target.Bytes(),
 		fact.design.Bytes(),
 		fact.cid.Bytes(),
 	)
@@ -78,7 +75,6 @@ func (fact CollectionRegisterFact) IsValid(b []byte) error {
 		nil, false,
 		fact.h,
 		fact.sender,
-		fact.target,
 		fact.design,
 		fact.cid); err != nil {
 		return err
@@ -99,19 +95,14 @@ func (fact CollectionRegisterFact) Sender() base.Address {
 	return fact.sender
 }
 
-func (fact CollectionRegisterFact) Target() base.Address {
-	return fact.target
-}
-
 func (fact CollectionRegisterFact) Design() nft.Design {
 	return fact.design
 }
 
 func (fact CollectionRegisterFact) Addresses() ([]base.Address, error) {
-	as := make([]base.Address, 2)
+	as := make([]base.Address, 1)
 
 	as[0] = fact.sender
-	as[1] = fact.target
 
 	return as, nil
 }

--- a/nft/collection/collection_register_bson.go
+++ b/nft/collection/collection_register_bson.go
@@ -16,7 +16,6 @@ func (fact CollectionRegisterFact) MarshalBSON() ([]byte, error) {
 				"hash":     fact.h,
 				"token":    fact.token,
 				"sender":   fact.sender,
-				"target":   fact.target,
 				"design":   fact.design,
 				"currency": fact.cid,
 			}))
@@ -26,7 +25,6 @@ type CollectionRegisterFactBSONUnpacker struct {
 	H  valuehash.Bytes     `bson:"hash"`
 	TK []byte              `bson:"token"`
 	SD base.AddressDecoder `bson:"sender"`
-	TG base.AddressDecoder `bson:"target"`
 	DS bson.Raw            `bson:"design"`
 	CR string              `bson:"currency"`
 }
@@ -37,7 +35,7 @@ func (fact *CollectionRegisterFact) UnpackBSON(b []byte, enc *bsonenc.Encoder) e
 		return err
 	}
 
-	return fact.unpack(enc, ufact.H, ufact.TK, ufact.SD, ufact.TG, ufact.DS, ufact.CR)
+	return fact.unpack(enc, ufact.H, ufact.TK, ufact.SD, ufact.DS, ufact.CR)
 }
 
 func (op *CollectionRegister) UnpackBSON(b []byte, enc *bsonenc.Encoder) error {

--- a/nft/collection/collection_register_encode.go
+++ b/nft/collection/collection_register_encode.go
@@ -14,16 +14,10 @@ func (fact *CollectionRegisterFact) unpack(
 	h valuehash.Hash,
 	token []byte,
 	bSender base.AddressDecoder,
-	bTarget base.AddressDecoder,
 	bDesign []byte,
 	cid string,
 ) error {
 	sender, err := bSender.Encode(enc)
-	if err != nil {
-		return err
-	}
-
-	target, err := bTarget.Encode(enc)
 	if err != nil {
 		return err
 	}
@@ -40,7 +34,6 @@ func (fact *CollectionRegisterFact) unpack(
 	fact.h = h
 	fact.token = token
 	fact.sender = sender
-	fact.target = target
 	fact.design = design
 	fact.cid = currency.CurrencyID(cid)
 

--- a/nft/collection/collection_register_json.go
+++ b/nft/collection/collection_register_json.go
@@ -15,7 +15,6 @@ type CollectionRegisterFactJSONPacker struct {
 	H  valuehash.Hash      `json:"hash"`
 	TK []byte              `json:"token"`
 	SD base.Address        `json:"sender"`
-	TG base.Address        `json:"target"`
 	DS nft.Design          `json:"design"`
 	CR currency.CurrencyID `json:"currency"`
 }
@@ -26,7 +25,6 @@ func (fact CollectionRegisterFact) MarshalJSON() ([]byte, error) {
 		H:          fact.h,
 		TK:         fact.token,
 		SD:         fact.sender,
-		TG:         fact.target,
 		DS:         fact.design,
 		CR:         fact.cid,
 	})
@@ -36,7 +34,6 @@ type CollectionRegisterFactJSONUnpacker struct {
 	H  valuehash.Bytes     `json:"hash"`
 	TK []byte              `json:"token"`
 	SD base.AddressDecoder `json:"sender"`
-	TG base.AddressDecoder `json:"target"`
 	DS json.RawMessage     `json:"design"`
 	CR string              `json:"currency"`
 }
@@ -47,7 +44,7 @@ func (fact *CollectionRegisterFact) UnpackJSON(b []byte, enc *jsonenc.Encoder) e
 		return err
 	}
 
-	return fact.unpack(enc, ufact.H, ufact.TK, ufact.SD, ufact.TG, ufact.DS, ufact.CR)
+	return fact.unpack(enc, ufact.H, ufact.TK, ufact.SD, ufact.DS, ufact.CR)
 }
 
 func (op *CollectionRegister) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {

--- a/nft/collection/delegate_item.go
+++ b/nft/collection/delegate_item.go
@@ -23,6 +23,10 @@ func (mode DelegateMode) String() string {
 	return string(mode)
 }
 
+func (mode DelegateMode) Equal(cmode DelegateMode) bool {
+	return string(mode) == string(cmode)
+}
+
 func (mode DelegateMode) IsValid([]byte) error {
 	if !(mode == DelegateAllow || mode == DelegateCancel) {
 		return isvalid.InvalidError.Errorf("wrong delegate mode; %s", mode)

--- a/nft/collection/nft_box.go
+++ b/nft/collection/nft_box.go
@@ -1,0 +1,216 @@
+package collection
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+
+	"github.com/ProtoconNet/mitum-nft/nft"
+	"github.com/pkg/errors"
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+	bsonenc "github.com/spikeekips/mitum/util/encoder/bson"
+	jsonenc "github.com/spikeekips/mitum/util/encoder/json"
+	"github.com/spikeekips/mitum/util/hint"
+	"github.com/spikeekips/mitum/util/valuehash"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+var (
+	NFTBoxType   = hint.Type("mitum-nft-nft-box")
+	NFTBoxHint   = hint.NewHint(NFTBoxType, "v0.0.1")
+	NFTBoxHinter = NFTBox{BaseHinter: hint.NewBaseHinter(NFTBoxHint)}
+)
+
+type NFTBox struct {
+	hint.BaseHinter
+	nfts []nft.NFTID
+}
+
+func NewNFTBox(nfts []nft.NFTID) NFTBox {
+	if nfts == nil {
+		return NFTBox{nfts: []nft.NFTID{}}
+	}
+	return NFTBox{nfts: nfts}
+}
+
+func (nbx NFTBox) Bytes() []byte {
+	bs := make([][]byte, len(nbx.nfts))
+	for i := range nbx.nfts {
+		bs[i] = nbx.nfts[i].Bytes()
+	}
+
+	return util.ConcatBytesSlice(bs...)
+}
+
+func (nbx NFTBox) Hint() hint.Hint {
+	return NFTBoxHint
+}
+
+func (nbx NFTBox) Hash() valuehash.Hash {
+	return nbx.GenerateHash()
+}
+
+func (nbx NFTBox) GenerateHash() valuehash.Hash {
+	return valuehash.NewSHA256(nbx.Bytes())
+}
+
+func (nbx NFTBox) IsEmpty() bool {
+	return len(nbx.nfts) < 1
+}
+
+func (nbx NFTBox) IsValid([]byte) error {
+	for i := range nbx.nfts {
+		if err := nbx.nfts[i].IsValid(nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (nbx NFTBox) Equal(b NFTBox) bool {
+	nbx.Sort(true)
+	b.Sort(true)
+	for i := range nbx.nfts {
+		if !nbx.nfts[i].Equal(b.nfts[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (nbx *NFTBox) Sort(ascending bool) {
+	sort.Slice(nbx.nfts, func(i, j int) bool {
+		if ascending {
+			return bytes.Compare(nbx.nfts[j].Bytes(), nbx.nfts[i].Bytes()) > 0
+		}
+		return bytes.Compare(nbx.nfts[j].Bytes(), nbx.nfts[i].Bytes()) < 0
+	})
+}
+
+func (nbx NFTBox) Exists(id nft.NFTID) bool {
+	if len(nbx.nfts) < 1 {
+		return false
+	}
+	for i := range nbx.nfts {
+		if id.Equal(nbx.nfts[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func (nbx NFTBox) Get(id nft.NFTID) (nft.NFTID, error) {
+	for i := range nbx.nfts {
+		if id.Equal(nbx.nfts[i]) {
+			return nbx.nfts[i], nil
+		}
+	}
+	return nft.NFTID{}, errors.Errorf("nft not found in owner's nft box; %v", id)
+}
+
+func (nbx *NFTBox) Append(n nft.NFTID) error {
+	if err := n.IsValid(nil); err != nil {
+		return err
+	}
+	if nbx.Exists(n) {
+		return errors.Errorf("nft %v already exists in nft box", n)
+	}
+	nbx.nfts = append(nbx.nfts, n)
+	return nil
+}
+
+func (nbx *NFTBox) Remove(n nft.NFTID) error {
+	if !nbx.Exists(n) {
+		return errors.Errorf("nft %v not found in nft box", n)
+	}
+	for i := range nbx.nfts {
+		if n.Equal(nbx.nfts[i]) {
+			nbx.nfts[i] = nbx.nfts[len(nbx.nfts)-1]
+			nbx.nfts[len(nbx.nfts)-1] = nft.NFTID{}
+			nbx.nfts = nbx.nfts[:len(nbx.nfts)-1]
+			return nil
+		}
+	}
+	return nil
+}
+
+func (nbx NFTBox) NFTs() []nft.NFTID {
+	return nbx.nfts
+}
+
+type NFTBoxJSONPacker struct {
+	jsonenc.HintedHead
+	NS []nft.NFTID `json:"nfts"`
+}
+
+func (nbx NFTBox) MarshalJSON() ([]byte, error) {
+	return jsonenc.Marshal(NFTBoxJSONPacker{
+		HintedHead: jsonenc.NewHintedHead(nbx.Hint()),
+		NS:         nbx.nfts,
+	})
+}
+
+type NFTBoxJSONUnpacker struct {
+	NS json.RawMessage `json:"nfts"`
+}
+
+func (nbx *NFTBox) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {
+	var un NFTBoxJSONUnpacker
+	if err := enc.Unmarshal(b, &un); err != nil {
+		return err
+	}
+
+	return nbx.unpack(enc, un.NS)
+}
+
+type NFTBoxBSONPacker struct {
+	AG []nft.NFTID `bson:"nfts"`
+}
+
+func (nbx NFTBox) MarshalBSON() ([]byte, error) {
+	return bsonenc.Marshal(bsonenc.MergeBSONM(
+		bsonenc.NewHintedDoc(nbx.Hint()),
+		bson.M{
+			"nfts": nbx.nfts,
+		}),
+	)
+}
+
+type NFTBoxBSONUnpacker struct {
+	NS bson.Raw `bson:"nfts"`
+}
+
+func (nbx *NFTBox) UnpackBSON(b []byte, enc *bsonenc.Encoder) error {
+	var un NFTBoxBSONUnpacker
+	if err := bsonenc.Unmarshal(b, &un); err != nil {
+		return err
+	}
+
+	return nbx.unpack(enc, un.NS)
+}
+
+func (nbx *NFTBox) unpack(
+	enc encoder.Encoder,
+	bNFTs []byte,
+) error {
+
+	hNFTs, err := enc.DecodeSlice(bNFTs)
+	if err != nil {
+		return err
+	}
+
+	nfts := make([]nft.NFTID, len(hNFTs))
+	for i := range hNFTs {
+		j, ok := hNFTs[i].(nft.NFTID)
+		if !ok {
+			return util.WrongTypeError.Errorf("not NFTID; %T", hNFTs[i])
+		}
+
+		nfts[i] = j
+	}
+
+	nbx.nfts = nfts
+
+	return nil
+}

--- a/nft/collection/state.go
+++ b/nft/collection/state.go
@@ -1,9 +1,174 @@
 package collection
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/ProtoconNet/mitum-account-extension/extension"
+	"github.com/ProtoconNet/mitum-nft/nft"
+	"github.com/pkg/errors"
+	"github.com/spikeekips/mitum-currency/currency"
+	"github.com/spikeekips/mitum/base"
 	"github.com/spikeekips/mitum/base/operation"
 	"github.com/spikeekips/mitum/base/state"
+	"github.com/spikeekips/mitum/util"
 )
+
+var (
+	StateKeyCollectionPrefix = "collection:"
+)
+
+var (
+	StateKeyAgentsSuffix            = ":agents"
+	StateKeyCollectionLastIDXSuffix = ":collectionidx"
+	StateKeyNFTsSuffix              = ":nfts"
+	StateKeyNFTSuffix               = ":nft"
+)
+
+func StateKeyAgents(addr base.Address) string {
+	return fmt.Sprintf("%s%s", addr.String(), StateKeyAgentsSuffix)
+}
+
+func IsStateAgentKey(key string) bool {
+	return strings.HasSuffix(key, StateKeyAgentsSuffix)
+}
+
+func StateAgentsValue(st state.State) (AgentBox, error) {
+	value := st.Value()
+	if value == nil {
+		return AgentBox{}, util.NotFoundError.Errorf("agent box not found in State")
+	}
+
+	if box, ok := value.Interface().(AgentBox); !ok {
+		return AgentBox{}, errors.Errorf("invalid agent box value found; %T", value.Interface())
+	} else {
+		return box, nil
+	}
+}
+
+func SetStateAgentsValue(st state.State, box AgentBox) (state.State, error) {
+	if vbox, err := state.NewHintedValue(box); err != nil {
+		return nil, err
+	} else {
+		return st.SetValue(vbox)
+	}
+}
+
+func StateKeyCollection(id extension.ContractID) string {
+	return fmt.Sprintf("%s%s", StateKeyCollectionPrefix, id.String())
+}
+
+func IsStateCollectionKey(key string) bool {
+	return strings.HasPrefix(key, StateKeyCollectionPrefix)
+}
+
+func StateCollectionValue(st state.State) (nft.Design, error) {
+	value := st.Value()
+	if value == nil {
+		return nft.Design{}, util.NotFoundError.Errorf("design not found in State")
+	}
+
+	if design, ok := value.Interface().(nft.Design); !ok {
+		return nft.Design{}, errors.Errorf("invalid design value found; %T", value.Interface())
+	} else {
+		return design, nil
+	}
+}
+
+func SetStateCollectionValue(st state.State, design nft.Design) (state.State, error) {
+	if vdesign, err := state.NewHintedValue(design); err != nil {
+		return nil, err
+	} else {
+		return st.SetValue(vdesign)
+	}
+}
+
+func StateKeyNFTs(addr base.Address) string {
+	return fmt.Sprintf("%s%s", addr.String(), StateKeyNFTsSuffix)
+}
+
+func IsStateNFTsKey(key string) bool {
+	return strings.HasSuffix(key, StateKeyNFTsSuffix)
+}
+
+func StateNFTsValue(st state.State) (NFTBox, error) {
+	value := st.Value()
+	if value == nil {
+		return NFTBox{}, util.NotFoundError.Errorf("nft box not found in State")
+	}
+
+	if box, ok := value.Interface().(NFTBox); !ok {
+		return NFTBox{}, errors.Errorf("invalid nft box value found; %T", value.Interface())
+	} else {
+		return box, nil
+	}
+}
+
+func SetStateNFTsValue(st state.State, box NFTBox) (state.State, error) {
+	if vbox, err := state.NewHintedValue(box); err != nil {
+		return nil, err
+	} else {
+		return st.SetValue(vbox)
+	}
+}
+
+func StateKeyNFT(id nft.NFTID) string {
+	return fmt.Sprintf("%s%s", id.String(), StateKeyNFTSuffix)
+}
+
+func IsStateNFTKey(key string) bool {
+	return strings.HasSuffix(key, StateKeyNFTSuffix)
+}
+
+func StateNFTValue(st state.State) (nft.NFT, error) {
+	value := st.Value()
+	if value == nil {
+		return nft.NFT{}, util.NotFoundError.Errorf("nft not found in State")
+	}
+
+	if n, ok := value.Interface().(nft.NFT); !ok {
+		return nft.NFT{}, errors.Errorf("invalid nft value found; %T", value.Interface())
+	} else {
+		return n, nil
+	}
+}
+
+func SetStateNFTValue(st state.State, n nft.NFT) (state.State, error) {
+	if vn, err := state.NewHintedValue(n); err != nil {
+		return nil, err
+	} else {
+		return st.SetValue(vn)
+	}
+}
+
+func StateKeyCollectionLastIDX(id extension.ContractID) string {
+	return fmt.Sprintf("%s%s", id.String(), StateKeyCollectionLastIDXSuffix)
+}
+
+func IsStateCollectionLastIDXKey(key string) bool {
+	return strings.HasSuffix(key, StateKeyCollectionLastIDXSuffix)
+}
+
+func StateCollectionLastIDXValue(st state.State) (currency.Big, error) {
+	value := st.Value()
+	if value == nil {
+		return currency.Big{}, util.NotFoundError.Errorf("collection idx not found in State")
+	}
+
+	if idx, ok := value.Interface().(currency.Big); !ok {
+		return currency.Big{}, errors.Errorf("invalid collection idx value found; %T", value.Interface())
+	} else {
+		return idx, nil
+	}
+}
+
+func SetStateCollectionLastIDXValue(st state.State, idx currency.Big) (state.State, error) {
+	if vidx, err := state.NewNumberValue(idx); err != nil {
+		return nil, err
+	} else {
+		return st.SetValue(vidx)
+	}
+}
 
 func checkExistsState(
 	key string,
@@ -16,6 +181,20 @@ func checkExistsState(
 		return operation.NewBaseReasonError("state, %q does not exist", key)
 	default:
 		return nil
+	}
+}
+
+func checkNotExistsState(
+	key string,
+	getState func(key string) (state.State, bool, error),
+) error {
+	switch _, found, err := getState(key); {
+	case err != nil:
+		return err
+	case !found:
+		return nil
+	default:
+		return operation.NewBaseReasonError("state, %q already exists", key)
 	}
 }
 

--- a/nft/collection/transfer.go
+++ b/nft/collection/transfer.go
@@ -31,8 +31,8 @@ type TransferItem interface {
 	isvalid.IsValider
 	NFTsItem
 	Bytes() []byte
-	From() base.Address
-	To() base.Address
+	Receiver() base.Address
+	Currency() currency.CurrencyID
 	Addresses() []base.Address
 	Rebuild() TransferItem
 }

--- a/nft/collection/transfer_item.go
+++ b/nft/collection/transfer_item.go
@@ -14,17 +14,15 @@ import (
 
 type BaseTransferItem struct {
 	hint.BaseHinter
-	from base.Address
-	to   base.Address
-	nfts []nft.NFTID
-	cid  currency.CurrencyID
+	receiver base.Address
+	nfts     []nft.NFTID
+	cid      currency.CurrencyID
 }
 
-func NewBaseTransferItem(ht hint.Hint, from base.Address, to base.Address, nfts []nft.NFTID, cid currency.CurrencyID) BaseTransferItem {
+func NewBaseTransferItem(ht hint.Hint, receiver base.Address, nfts []nft.NFTID, cid currency.CurrencyID) BaseTransferItem {
 	return BaseTransferItem{
 		BaseHinter: hint.NewBaseHinter(ht),
-		from:       from,
-		to:         to,
+		receiver:   receiver,
 		nfts:       nfts,
 		cid:        cid,
 	}
@@ -38,15 +36,14 @@ func (it BaseTransferItem) Bytes() []byte {
 	}
 
 	return util.ConcatBytesSlice(
-		it.from.Bytes(),
-		it.to.Bytes(),
+		it.receiver.Bytes(),
 		it.cid.Bytes(),
 		util.ConcatBytesSlice(ns...),
 	)
 }
 
 func (it BaseTransferItem) IsValid([]byte) error {
-	if err := isvalid.Check(nil, false, it.BaseHinter, it.from, it.to, it.cid); err != nil {
+	if err := isvalid.Check(nil, false, it.BaseHinter, it.receiver, it.cid); err != nil {
 		return err
 	}
 
@@ -69,18 +66,13 @@ func (it BaseTransferItem) IsValid([]byte) error {
 	return nil
 }
 
-func (it BaseTransferItem) From() base.Address {
-	return it.from
-}
-
-func (it BaseTransferItem) To() base.Address {
-	return it.to
+func (it BaseTransferItem) Receiver() base.Address {
+	return it.receiver
 }
 
 func (it BaseTransferItem) Addresses() []base.Address {
-	as := make([]base.Address, 2)
-	as[0] = it.From()
-	as[1] = it.To()
+	as := make([]base.Address, 1)
+	as[0] = it.receiver
 	return as
 }
 

--- a/nft/collection/transfer_item_bson.go
+++ b/nft/collection/transfer_item_bson.go
@@ -11,8 +11,7 @@ func (it BaseTransferItem) MarshalBSON() ([]byte, error) {
 	return bsonenc.Marshal(
 		bsonenc.MergeBSONM(bsonenc.NewHintedDoc(it.Hint()),
 			bson.M{
-				"from":     it.from,
-				"to":       it.to,
+				"receiver": it.receiver,
 				"nfts":     it.nfts,
 				"currency": it.cid,
 			}),
@@ -20,8 +19,7 @@ func (it BaseTransferItem) MarshalBSON() ([]byte, error) {
 }
 
 type BaseTransferItemBSONUnpacker struct {
-	FR base.AddressDecoder `bson:"from"`
-	TO base.AddressDecoder `bson:"to"`
+	RC base.AddressDecoder `bson:"receiver"`
 	NS bson.Raw            `bson:"nfts"`
 	CR string              `bson:"currency"`
 }
@@ -32,5 +30,5 @@ func (it *BaseTransferItem) UnpackBSON(b []byte, enc *bsonenc.Encoder) error {
 		return err
 	}
 
-	return it.unpack(enc, uit.FR, uit.TO, uit.NS, uit.CR)
+	return it.unpack(enc, uit.RC, uit.NS, uit.CR)
 }

--- a/nft/collection/transfer_item_encode.go
+++ b/nft/collection/transfer_item_encode.go
@@ -11,17 +11,11 @@ import (
 
 func (it *BaseTransferItem) unpack(
 	enc encoder.Encoder,
-	bFrom base.AddressDecoder,
-	bTo base.AddressDecoder,
+	bReceiver base.AddressDecoder,
 	bNFTs []byte,
 	cid string,
 ) error {
-	from, err := bFrom.Encode(enc)
-	if err != nil {
-		return err
-	}
-
-	to, err := bTo.Encode(enc)
+	receiver, err := bReceiver.Encode(enc)
 	if err != nil {
 		return err
 	}
@@ -41,8 +35,7 @@ func (it *BaseTransferItem) unpack(
 		nfts[i] = j
 	}
 
-	it.from = from
-	it.to = to
+	it.receiver = receiver
 	it.nfts = nfts
 	it.cid = currency.CurrencyID(cid)
 

--- a/nft/collection/transfer_item_json.go
+++ b/nft/collection/transfer_item_json.go
@@ -12,8 +12,7 @@ import (
 
 type TransferItemJSONPacker struct {
 	jsonenc.HintedHead
-	FR base.Address        `json:"from"`
-	TO base.Address        `json:"to"`
+	RC base.Address        `json:"receiver"`
 	NS []nft.NFTID         `json:"nfts"`
 	CR currency.CurrencyID `json:"currency"`
 }
@@ -21,16 +20,14 @@ type TransferItemJSONPacker struct {
 func (it BaseTransferItem) MarshalJSON() ([]byte, error) {
 	return jsonenc.Marshal(TransferItemJSONPacker{
 		HintedHead: jsonenc.NewHintedHead(it.Hint()),
-		FR:         it.from,
-		TO:         it.to,
+		RC:         it.receiver,
 		NS:         it.nfts,
 		CR:         it.cid,
 	})
 }
 
 type TransferItemJSONUnpacker struct {
-	FR base.AddressDecoder `json:"from"`
-	TO base.AddressDecoder `json:"to"`
+	RC base.AddressDecoder `json:"receiver"`
 	NS json.RawMessage     `json:"nfts"`
 	CR string              `json:"currency"`
 }
@@ -41,5 +38,5 @@ func (it *BaseTransferItem) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {
 		return err
 	}
 
-	return it.unpack(enc, utn.FR, utn.TO, utn.NS, utn.CR)
+	return it.unpack(enc, utn.RC, utn.NS, utn.CR)
 }

--- a/nft/collection/transfer_multi_nfts.go
+++ b/nft/collection/transfer_multi_nfts.go
@@ -25,9 +25,9 @@ type TransferItemMultiNFTs struct {
 	BaseTransferItem
 }
 
-func NewTransferItemMultiNFTs(from base.Address, to base.Address, nfts []nft.NFTID, cid currency.CurrencyID) TransferItemMultiNFTs {
+func NewTransferItemMultiNFTs(receiver base.Address, nfts []nft.NFTID, cid currency.CurrencyID) TransferItemMultiNFTs {
 	return TransferItemMultiNFTs{
-		BaseTransferItem: NewBaseTransferItem(TransferItemMultiNFTsHint, from, to, nfts, cid),
+		BaseTransferItem: NewBaseTransferItem(TransferItemMultiNFTsHint, receiver, nfts, cid),
 	}
 }
 

--- a/nft/collection/transfer_single_nft.go
+++ b/nft/collection/transfer_single_nft.go
@@ -23,9 +23,9 @@ type TransferItemSingleNFT struct {
 	BaseTransferItem
 }
 
-func NewTransferItemSingleNFT(from, to base.Address, nftid nft.NFTID, cid currency.CurrencyID) TransferItemSingleNFT {
+func NewTransferItemSingleNFT(receiver base.Address, nftid nft.NFTID, cid currency.CurrencyID) TransferItemSingleNFT {
 	return TransferItemSingleNFT{
-		BaseTransferItem: NewBaseTransferItem(TransferItemSingleNFTHint, from, to, []nft.NFTID{nftid}, cid),
+		BaseTransferItem: NewBaseTransferItem(TransferItemSingleNFTHint, receiver, []nft.NFTID{nftid}, cid),
 	}
 }
 

--- a/nft/nft.go
+++ b/nft/nft.go
@@ -14,6 +14,10 @@ import (
 
 var BLACKHOLE_ZERO = currency.NewAddress("blackhole-0")
 
+func isCollectionEqual(c1 extension.ContractID, c2 extension.ContractID) bool {
+	return c1.String() == c2.String()
+}
+
 var (
 	NFTIDType   = hint.Type("mitum-nft-nft-id")
 	NFTIDHint   = hint.NewHint(NFTIDType, "v0.0.1")
@@ -79,6 +83,10 @@ func (nid NFTID) String() string {
 	return fmt.Sprintf("%s-%s)", nid.collection.String(), nid.idx.String())
 }
 
+func (nid NFTID) Equal(cnid NFTID) bool {
+	return isCollectionEqual(nid.collection, cnid.collection) && nid.idx.Equal(cnid.idx)
+}
+
 type NFTHash string
 
 func (hs NFTHash) Bytes() []byte {
@@ -98,13 +106,7 @@ func (hs NFTHash) IsValid([]byte) error {
 }
 
 var (
-	CopyrighterType   = hint.Type("mitum-nft-copyrighter")
-	CopyrighterHint   = hint.NewHint(CopyrighterType, "v0.0.1")
-	CopyrighterHinter = NFT{BaseHinter: hint.NewBaseHinter(CopyrighterHint)}
-)
-
-var (
-	NFTType   = hint.Type("mitum-nft-post-info")
+	NFTType   = hint.Type("mitum-nft-nft")
 	NFTHint   = hint.NewHint(NFTType, "v0.0.1")
 	NFTHinter = NFT{BaseHinter: hint.NewBaseHinter(NFTHint)}
 )

--- a/nft/policy.go
+++ b/nft/policy.go
@@ -2,6 +2,7 @@ package nft
 
 import (
 	"github.com/ProtoconNet/mitum-account-extension/extension"
+	"github.com/spikeekips/mitum/base"
 	"github.com/spikeekips/mitum/util"
 	"github.com/spikeekips/mitum/util/hint"
 	"github.com/spikeekips/mitum/util/isvalid"
@@ -29,25 +30,29 @@ func (pp PaymentParameter) IsValid([]byte) error {
 var (
 	DesignType   = hint.Type("mitum-nft-design")
 	DesignHint   = hint.NewHint(DesignType, "v0.0.1")
-	DesignHinter = NFT{BaseHinter: hint.NewBaseHinter(DesignHint)}
+	DesignHinter = Design{BaseHinter: hint.NewBaseHinter(DesignHint)}
 )
 
 type Design struct {
 	hint.BaseHinter
-	symbol extension.ContractID
-	policy BasePolicy
+	parent  base.Address
+	creator base.Address
+	symbol  extension.ContractID
+	policy  BasePolicy
 }
 
-func NewDesign(symbol extension.ContractID, policy BasePolicy) Design {
+func NewDesign(parent base.Address, creator base.Address, symbol extension.ContractID, policy BasePolicy) Design {
 	return Design{
 		BaseHinter: hint.NewBaseHinter(DesignHint),
+		parent:     parent,
+		creator:    creator,
 		symbol:     symbol,
 		policy:     policy,
 	}
 }
 
-func MustNewDesign(symbol extension.ContractID, policy BasePolicy) Design {
-	d := NewDesign(symbol, policy)
+func MustNewDesign(parent base.Address, creator base.Address, symbol extension.ContractID, policy BasePolicy) Design {
+	d := NewDesign(parent, creator, symbol, policy)
 	if err := d.IsValid(nil); err != nil {
 		panic(err)
 	}
@@ -56,9 +61,19 @@ func MustNewDesign(symbol extension.ContractID, policy BasePolicy) Design {
 
 func (d Design) Bytes() []byte {
 	return util.ConcatBytesSlice(
+		d.parent.Bytes(),
+		d.creator.Bytes(),
 		d.symbol.Bytes(),
 		d.policy.Bytes(),
 	)
+}
+
+func (d Design) Parent() base.Address {
+	return d.parent
+}
+
+func (d Design) Creator() base.Address {
+	return d.creator
 }
 
 func (d Design) Symbol() extension.ContractID {
@@ -73,6 +88,8 @@ func (d Design) IsValid([]byte) error {
 	if err := isvalid.Check(
 		nil, false,
 		d.BaseHinter,
+		d.parent,
+		d.creator,
 		d.symbol,
 		d.policy); err != nil {
 		return err

--- a/nft/policy_bson.go
+++ b/nft/policy_bson.go
@@ -3,6 +3,7 @@ package nft
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
+	"github.com/spikeekips/mitum/base"
 	bsonenc "github.com/spikeekips/mitum/util/encoder/bson"
 )
 
@@ -10,14 +11,18 @@ func (d Design) MarshalBSON() ([]byte, error) {
 	return bsonenc.Marshal(
 		bsonenc.MergeBSONM(bsonenc.NewHintedDoc(d.Hint()),
 			bson.M{
-				"symbol": d.symbol,
-				"policy": d.policy,
+				"parent":  d.parent,
+				"creator": d.creator,
+				"symbol":  d.symbol,
+				"policy":  d.policy,
 			}))
 }
 
 type DesignBSONUnpacker struct {
-	SB string   `bson:"symbol"`
-	PO bson.Raw `bson:"policy"`
+	PR base.AddressDecoder `bson:"parent"`
+	CR base.AddressDecoder `bson:"creator"`
+	SB string              `bson:"symbol"`
+	PO bson.Raw            `bson:"policy"`
 }
 
 func (d *Design) UnpackBSON(b []byte, enc *bsonenc.Encoder) error {
@@ -26,5 +31,5 @@ func (d *Design) UnpackBSON(b []byte, enc *bsonenc.Encoder) error {
 		return err
 	}
 
-	return d.unpack(enc, ud.SB, ud.PO)
+	return d.unpack(enc, ud.PR, ud.CR, ud.SB, ud.PO)
 }

--- a/nft/policy_encode.go
+++ b/nft/policy_encode.go
@@ -2,15 +2,31 @@ package nft
 
 import (
 	"github.com/ProtoconNet/mitum-account-extension/extension"
+	"github.com/spikeekips/mitum/base"
 	"github.com/spikeekips/mitum/util"
 	"github.com/spikeekips/mitum/util/encoder"
 )
 
 func (d *Design) unpack(
 	enc encoder.Encoder,
+	bParent base.AddressDecoder,
+	bCreator base.AddressDecoder,
 	_symbol string,
 	bPolicy []byte,
 ) error {
+
+	parent, err := bParent.Encode(enc)
+	if err != nil {
+		return err
+	}
+	d.parent = parent
+
+	creator, err := bCreator.Encode(enc)
+	if err != nil {
+		return err
+	}
+	d.creator = creator
+
 	d.symbol = extension.ContractID(_symbol)
 
 	var policy BasePolicy

--- a/nft/policy_json.go
+++ b/nft/policy_json.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 
 	"github.com/ProtoconNet/mitum-account-extension/extension"
+	"github.com/spikeekips/mitum/base"
 	jsonenc "github.com/spikeekips/mitum/util/encoder/json"
 )
 
 type DesignJSONPacker struct {
 	jsonenc.HintedHead
+	PR base.Address         `json:"parent"`
+	CR base.Address         `json:"creator"`
 	SB extension.ContractID `json:"symbol"`
 	PO BasePolicy           `json:"policy"`
 }
@@ -16,14 +19,18 @@ type DesignJSONPacker struct {
 func (d Design) MarshalJSON() ([]byte, error) {
 	return jsonenc.Marshal(DesignJSONPacker{
 		HintedHead: jsonenc.NewHintedHead(d.Hint()),
+		PR:         d.parent,
+		CR:         d.creator,
 		SB:         d.symbol,
 		PO:         d.policy,
 	})
 }
 
 type DesignJSONUnpacker struct {
-	SB string          `json:"symbol"`
-	PO json.RawMessage `json:"policy"`
+	PR base.AddressDecoder `json:"parent"`
+	CR base.AddressDecoder `json:"creator"`
+	SB string              `json:"symbol"`
+	PO json.RawMessage     `json:"policy"`
 }
 
 func (d *Design) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {
@@ -32,5 +39,5 @@ func (d *Design) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {
 		return err
 	}
 
-	return d.unpack(enc, ud.SB, ud.PO)
+	return d.unpack(enc, ud.PR, ud.CR, ud.SB, ud.PO)
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feat : declare states - agents, collection,  collection id, nfts, nft

* **What is the current behavior?** (You can also link to an open issue here)
No states in the package.
from(nft owner) and to(nft receiver) are necessary for nft transfer operation.
No limit on the number of nfts/collection.

* **What is the new behavior (if this is a feature change)?**
agent box, nft box have been implemented.
Using just 'receiver' instead of 'from' and 'to' for nft transfer.
There is a limit on the number of nfts/collection.

* **Other information**:
No limit on the number of nfts/collection if limit=0. (not implemented yet)
node init success