### PR TITLE
Update operation processor; delete deactivate - invalid operation

### DIFF
--- a/nft/collection/operation_processor.go
+++ b/nft/collection/operation_processor.go
@@ -165,7 +165,6 @@ func (opr *OperationProcessor) Process(op state.Processor) error {
 		extensioncurrency.CurrencyPolicyUpdater,
 		extensioncurrency.SuffrageInflation,
 		extensioncurrency.CreateContractAccounts,
-		extensioncurrency.Deactivate,
 		extensioncurrency.Withdraws,
 		Delegate,
 		Approve,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix; deactivate operation is now invalid in mitum-currency-extension

* **What is the current behavior?** (You can also link to an open issue here)
Invalid operation - deactivate remains in the codes.

* **What is the new behavior (if this is a feature change)?**
Deactivate operation has been removed.

* **Other information**: