### PR TITLE
Update nft; add active to nft

### DIFF
--- a/nft/collection/approve_process.go
+++ b/nft/collection/approve_process.go
@@ -61,7 +61,7 @@ func (ipp *ApproveItemProcessor) PreProcess(
 	} else if design, err := StateCollectionValue(st); err != nil {
 		return err
 	} else if !design.Active() {
-		return errors.Errorf("dead collection; %q", nid.Collection())
+		return errors.Errorf("deactivated collection; %q", nid.Collection())
 	}
 
 	if st, err := existsState(StateKeyNFT(nid), "nft", getState); err != nil {
@@ -69,7 +69,7 @@ func (ipp *ApproveItemProcessor) PreProcess(
 	} else if nv, err := StateNFTValue(st); err != nil {
 		return err
 	} else if !nv.Active() {
-		return errors.Errorf("dead nft; %q", nid)
+		return errors.Errorf("burned nft; %q", nid)
 	} else {
 		ipp.nft = nv
 		ipp.nst = st

--- a/nft/collection/burn_process.go
+++ b/nft/collection/burn_process.go
@@ -82,22 +82,19 @@ func (ipp *BurnItemProcessor) PreProcess(
 		return err
 	} else if nv, err := StateNFTValue(st); err != nil {
 		return err
+	} else if !nv.Active() {
+		return errors.Errorf("dead nft; %q", nid)
 	} else {
 		approved = nv.Approved()
 		owner = nv.Owner()
 
-		n := nft.NewNFT(nv.ID(), currency.Address{}, nv.NftHash(), nv.Uri(), currency.Address{}, nv.Creators(), nv.Copyrighters())
+		n := nft.NewNFT(nv.ID(), false, nv.Owner(), nv.NftHash(), nv.Uri(), nv.Owner(), nv.Creators(), nv.Copyrighters())
 		if err := n.IsValid(nil); err != nil {
 			return err
 		}
 
 		ipp.nft = n
 		ipp.nst = st
-	}
-
-	// check owner
-	if owner.String() == "" {
-		return errors.Errorf("dead nft; %q", nid)
 	}
 
 	// check authorization

--- a/nft/collection/burn_process.go
+++ b/nft/collection/burn_process.go
@@ -60,7 +60,7 @@ func (ipp *BurnItemProcessor) PreProcess(
 	} else if design, err := StateCollectionValue(st); err != nil {
 		return err
 	} else if !design.Active() {
-		return errors.Errorf("dead collection; %q", nid.Collection())
+		return errors.Errorf("deactivated collection; %q", nid.Collection())
 	}
 
 	if st, err := existsState(StateKeyNFTs(nid.Collection()), "nfts", getState); err != nil {
@@ -83,7 +83,7 @@ func (ipp *BurnItemProcessor) PreProcess(
 	} else if nv, err := StateNFTValue(st); err != nil {
 		return err
 	} else if !nv.Active() {
-		return errors.Errorf("dead nft; %q", nid)
+		return errors.Errorf("burned nft; %q", nid)
 	} else {
 		approved = nv.Approved()
 		owner = nv.Owner()

--- a/nft/collection/delegate_process.go
+++ b/nft/collection/delegate_process.go
@@ -153,7 +153,7 @@ func (opp *DelegateProcessor) PreProcess(
 		} else if design, err := StateCollectionValue(st); err != nil {
 			return nil, operation.NewBaseReasonError(err.Error())
 		} else if !design.Active() {
-			return nil, operation.NewBaseReasonError("dead collection; %q", item.Collection())
+			return nil, operation.NewBaseReasonError("deactivated collection; %q", item.Collection())
 		}
 
 		var box AgentBox

--- a/nft/collection/mint_process.go
+++ b/nft/collection/mint_process.go
@@ -117,7 +117,7 @@ func (ipp *MintItemProcessor) PreProcess(
 		}
 	}
 
-	n := nft.NewNFT(id, ipp.sender, form.NftHash(), form.Uri(), currency.Address{}, form.Creators(), form.Copyrighters())
+	n := nft.NewNFT(id, true, ipp.sender, form.NftHash(), form.Uri(), ipp.sender, form.Creators(), form.Copyrighters())
 	if err := n.IsValid(nil); err != nil {
 		return operation.NewBaseReasonError(err.Error())
 	}

--- a/nft/collection/mint_process.go
+++ b/nft/collection/mint_process.go
@@ -58,7 +58,7 @@ func (ipp *MintItemProcessor) PreProcess(
 	} else if design, err := StateCollectionValue(st); err != nil {
 		return err
 	} else if !design.Active() {
-		return errors.Errorf("dead collection; %q", design.Symbol())
+		return errors.Errorf("deactivated collection; %q", design.Symbol())
 	} else if !ipp.sender.Equal(design.Creator()) {
 		return errors.Errorf("sender must be collection creator; creator: %q", design.Creator().String())
 	}

--- a/nft/collection/sign_process.go
+++ b/nft/collection/sign_process.go
@@ -69,6 +69,8 @@ func (ipp *SignItemProcessor) PreProcess(
 		return err
 	} else if nv, err := StateNFTValue(st); err != nil {
 		return err
+	} else if !nv.Active() {
+		return errors.Errorf("dead nft; %q", nid)
 	} else {
 		switch ipp.item.Qualification() {
 		case CreatorQualification:
@@ -80,11 +82,6 @@ func (ipp *SignItemProcessor) PreProcess(
 		}
 		n = nv
 		ipp.nst = st
-	}
-
-	// check owner
-	if n.Owner().String() == "" {
-		return errors.Errorf("dead nft; %q", nid)
 	}
 
 	var idx = -1
@@ -109,9 +106,9 @@ func (ipp *SignItemProcessor) PreProcess(
 	signers[idx] = signer
 
 	if ipp.item.Qualification() == CreatorQualification {
-		n = nft.NewNFT(n.ID(), n.Owner(), n.NftHash(), n.Uri(), n.Approved(), signers, n.Copyrighters())
+		n = nft.NewNFT(n.ID(), n.Active(), n.Owner(), n.NftHash(), n.Uri(), n.Approved(), signers, n.Copyrighters())
 	} else {
-		n = nft.NewNFT(n.ID(), n.Owner(), n.NftHash(), n.Uri(), n.Approved(), n.Creators(), signers)
+		n = nft.NewNFT(n.ID(), n.Active(), n.Owner(), n.NftHash(), n.Uri(), n.Approved(), n.Creators(), signers)
 	}
 
 	if err := n.IsValid(nil); err != nil {

--- a/nft/collection/sign_process.go
+++ b/nft/collection/sign_process.go
@@ -58,7 +58,7 @@ func (ipp *SignItemProcessor) PreProcess(
 	} else if design, err := StateCollectionValue(st); err != nil {
 		return err
 	} else if !design.Active() {
-		return errors.Errorf("dead collection; %q", nid.Collection())
+		return errors.Errorf("deactivated collection; %q", nid.Collection())
 	}
 
 	var signers []nft.Signer
@@ -70,7 +70,7 @@ func (ipp *SignItemProcessor) PreProcess(
 	} else if nv, err := StateNFTValue(st); err != nil {
 		return err
 	} else if !nv.Active() {
-		return errors.Errorf("dead nft; %q", nid)
+		return errors.Errorf("burned nft; %q", nid)
 	} else {
 		switch ipp.item.Qualification() {
 		case CreatorQualification:

--- a/nft/collection/transfer_process.go
+++ b/nft/collection/transfer_process.go
@@ -65,7 +65,7 @@ func (ipp *TransferItemProcessor) PreProcess(
 	} else if design, err := StateCollectionValue(st); err != nil {
 		return err
 	} else if !design.Active() {
-		return errors.Errorf("dead collection; %q", design.Symbol())
+		return errors.Errorf("deactivated collection; %q", design.Symbol())
 	}
 
 	var (
@@ -79,7 +79,7 @@ func (ipp *TransferItemProcessor) PreProcess(
 	} else if nv, err := StateNFTValue(st); err != nil {
 		return err
 	} else if !nv.Active() {
-		return errors.Errorf("dead nft; %q", nid)
+		return errors.Errorf("burned nft; %q", nid)
 	} else {
 		approved = nv.Approved()
 		owner = nv.Owner()

--- a/nft/collection/transfer_process.go
+++ b/nft/collection/transfer_process.go
@@ -78,22 +78,19 @@ func (ipp *TransferItemProcessor) PreProcess(
 		return err
 	} else if nv, err := StateNFTValue(st); err != nil {
 		return err
+	} else if !nv.Active() {
+		return errors.Errorf("dead nft; %q", nid)
 	} else {
 		approved = nv.Approved()
 		owner = nv.Owner()
 
-		n := nft.NewNFT(nid, receiver, nv.NftHash(), nv.Uri(), currency.Address{}, nv.Creators(), nv.Copyrighters())
+		n := nft.NewNFT(nid, nv.Active(), receiver, nv.NftHash(), nv.Uri(), receiver, nv.Creators(), nv.Copyrighters())
 		if err := n.IsValid(nil); err != nil {
 			return err
 		}
 
 		ipp.nft = n
 		ipp.nst = st
-	}
-
-	// check owner
-	if owner.String() == "" {
-		return errors.Errorf("dead nft; %q", nid)
 	}
 
 	// check authorization

--- a/nft/nft_bson.go
+++ b/nft/nft_bson.go
@@ -12,6 +12,7 @@ func (n NFT) MarshalBSON() ([]byte, error) {
 		bsonenc.NewHintedDoc(n.Hint()),
 		bson.M{
 			"id":           n.id,
+			"active":       n.active,
 			"owner":        n.owner,
 			"hash":         n.hash,
 			"uri":          n.uri,
@@ -24,6 +25,7 @@ func (n NFT) MarshalBSON() ([]byte, error) {
 
 type NFTBSONUnpacker struct {
 	ID bson.Raw            `bson:"id"`
+	AC bool                `bson:"active"`
 	ON base.AddressDecoder `bson:"owner"`
 	HS string              `bson:"hash"`
 	UR string              `bson:"uri"`
@@ -38,5 +40,5 @@ func (n *NFT) UnpackBSON(b []byte, enc *bsonenc.Encoder) error {
 		return err
 	}
 
-	return n.unpack(enc, un.ID, un.ON, un.HS, un.UR, un.AP, un.CR, un.CP)
+	return n.unpack(enc, un.ID, un.AC, un.ON, un.HS, un.UR, un.AP, un.CR, un.CP)
 }

--- a/nft/nft_encode.go
+++ b/nft/nft_encode.go
@@ -9,6 +9,7 @@ import (
 func (n *NFT) unpack(
 	enc encoder.Encoder,
 	bid []byte,
+	active bool,
 	bo base.AddressDecoder,
 	hash string,
 	uri string,
@@ -23,6 +24,8 @@ func (n *NFT) unpack(
 	} else {
 		n.id = id
 	}
+
+	n.active = active
 
 	owner, err := bo.Encode(enc)
 	if err != nil {

--- a/nft/nft_json.go
+++ b/nft/nft_json.go
@@ -10,6 +10,7 @@ import (
 type NFTJSONPacker struct {
 	jsonenc.HintedHead
 	ID NFTID        `json:"id"`
+	AC bool         `json:"active"`
 	ON base.Address `json:"owner"`
 	HS NFTHash      `json:"hash"`
 	UR URI          `json:"uri"`
@@ -22,6 +23,7 @@ func (n NFT) MarshalJSON() ([]byte, error) {
 	return jsonenc.Marshal(NFTJSONPacker{
 		HintedHead: jsonenc.NewHintedHead(n.Hint()),
 		ID:         n.id,
+		AC:         n.active,
 		ON:         n.owner,
 		HS:         n.hash,
 		UR:         n.uri,
@@ -33,6 +35,7 @@ func (n NFT) MarshalJSON() ([]byte, error) {
 
 type NFTJSONUnpacker struct {
 	ID json.RawMessage     `json:"id"`
+	AC bool                `json:"active"`
 	ON base.AddressDecoder `json:"owner"`
 	HS string              `json:"hash"`
 	UR string              `json:"uri"`
@@ -47,5 +50,5 @@ func (n *NFT) UnpackJSON(b []byte, enc *jsonenc.Encoder) error {
 		return err
 	}
 
-	return n.unpack(enc, un.ID, un.ON, un.HS, un.UR, un.AP, un.CR, un.CP)
+	return n.unpack(enc, un.ID, un.AC, un.ON, un.HS, un.UR, un.AP, un.CR, un.CP)
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix; add active field to nft.NFT

* **What is the current behavior?** (You can also link to an open issue here)
1. approved address becomes to be empty when minting, transferring and burning nft.
2. owner address becomes to be empty when burning nft.

* **What is the new behavior (if this is a feature change)?**
1. approved address is owner itself when approved account is not set.
2. owner address is not empty even if nft is deactivated.
3. checking if nft is deactivated by NFT.Active().

* **Other information**: