### PR TITLE
Allow duplicate collection in operation when minting and burning

### DIFF
--- a/nft/collection/collection_policy_updater.go
+++ b/nft/collection/collection_policy_updater.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	CollectionPolicyUpdaterFactType   = hint.Type("mitum-nft-collection-policy-updater-fact")
+	CollectionPolicyUpdaterFactType   = hint.Type("mitum-nft-collection-policy-updater-operation-fact")
 	CollectionPolicyUpdaterFactHint   = hint.NewHint(CollectionPolicyUpdaterFactType, "v0.0.1")
 	CollectionPolicyUpdaterFactHinter = CollectionPolicyUpdaterFact{BaseHinter: hint.NewBaseHinter(CollectionPolicyUpdaterFactHint)}
 	CollectionPolicyUpdaterType       = hint.Type("mitum-nft-collection-policy-updater-operation")

--- a/nft/collection/mint.go
+++ b/nft/collection/mint.go
@@ -1,7 +1,6 @@
 package collection
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/currency"
 	"github.com/pkg/errors"
 	"github.com/spikeekips/mitum-currency/currency"
 	"github.com/spikeekips/mitum/base"
@@ -88,20 +87,6 @@ func (fact MintFact) IsValid(b []byte) error {
 		fact.h,
 		fact.sender); err != nil {
 		return err
-	}
-
-	founds := map[extensioncurrency.ContractID]struct{}{}
-	for i := range fact.items {
-
-		if err := fact.items[i].IsValid(nil); err != nil {
-			return err
-		}
-
-		c := fact.items[i].Collection()
-		if _, found := founds[c]; found {
-			return errors.Errorf("duplicate collection found; %q", c)
-		}
-		founds[c] = struct{}{}
 	}
 
 	if !fact.h.Equal(fact.GenerateHash()) {

--- a/nft/collection/mint_process.go
+++ b/nft/collection/mint_process.go
@@ -209,13 +209,15 @@ func (opp *MintProcessor) PreProcess(
 				return nil, operation.NewBaseReasonError("deactivated collection; %q", design.Symbol())
 			} else if policy, ok := design.Policy().(CollectionPolicy); !ok {
 				return nil, operation.NewBaseReasonError("policy of design is not collection-policy; %q", design.Symbol())
-			} else if whites := policy.Whites(); !design.Creator().Equal(fact.Sender()) {
+			} else if whites := policy.Whites(); len(whites) == 0 {
+				return nil, operation.NewBaseReasonError("empty whitelist! nobody can mint to this collection; %q", collection)
+			} else {
 				for i := range whites {
 					if whites[i].Equal(fact.Sender()) {
 						break
 					}
 					if i == len(whites)-1 {
-						return nil, operation.NewBaseReasonError("sender is not whitelisted, nor is collection creator; %q", fact.Sender())
+						return nil, operation.NewBaseReasonError("sender is not whitelisted; %q", fact.Sender())
 					}
 				}
 			}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore; allow duplication collection in mint / burn operations.

* **What is the current behavior?** (You can also link to an open issue here)
The target collection of each (mint, burn)item must not be duplicate.
It is not possible to process multiple nfts of the same collection in one operation.

* **What is the new behavior (if this is a feature change)?**
The collection of each (mint, burn)item doesn't matter.

* **Other information**: