### PR TITLE
Fix mint, sign, delegate validation check

### DIFF
--- a/nft/collection/approve_process.go
+++ b/nft/collection/approve_process.go
@@ -142,7 +142,7 @@ func NewApproveProcessor(cp *extensioncurrency.CurrencyPool) currency.GetNewProc
 	return func(op state.Processor) (state.Processor, error) {
 		i, ok := op.(Approve)
 		if !ok {
-			return nil, operation.NewBaseReasonError("not Approve; %T", op)
+			return nil, errors.Errorf("not Approve; %T", op)
 		}
 
 		opp := ApproveProcessorPool.Get().(*ApproveProcessor)
@@ -162,7 +162,10 @@ func (opp *ApproveProcessor) PreProcess(
 	getState func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) (state.Processor, error) {
-	fact := opp.Fact().(ApproveFact)
+	fact, ok := opp.Fact().(ApproveFact)
+	if !ok {
+		return nil, operation.NewBaseReasonError("not ApproveFact; %T", opp.Fact())
+	}
 
 	if err := checkExistsState(currency.StateKeyAccount(fact.Sender()), getState); err != nil {
 		return nil, operation.NewBaseReasonError(err.Error())
@@ -208,7 +211,10 @@ func (opp *ApproveProcessor) Process(
 	getState func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) error {
-	fact := opp.Fact().(ApproveFact)
+	fact, ok := opp.Fact().(ApproveFact)
+	if !ok {
+		return operation.NewBaseReasonError("not ApproveFact; %T", opp.Fact())
+	}
 
 	var states []state.State
 
@@ -245,7 +251,10 @@ func (opp *ApproveProcessor) Close() error {
 }
 
 func (opp *ApproveProcessor) calculateItemsFee() (map[currency.CurrencyID][2]currency.Big, error) {
-	fact := opp.Fact().(ApproveFact)
+	fact, ok := opp.Fact().(ApproveFact)
+	if !ok {
+		return nil, errors.Errorf("not ApproveFact; %T", opp.Fact())
+	}
 
 	items := make([]ApproveItem, len(fact.items))
 	for i := range fact.items {

--- a/nft/collection/burn_process.go
+++ b/nft/collection/burn_process.go
@@ -161,7 +161,10 @@ func (opp *BurnProcessor) PreProcess(
 	getState func(string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) (state.Processor, error) {
-	fact := opp.Fact().(BurnFact)
+	fact, ok := opp.Fact().(BurnFact)
+	if !ok {
+		return nil, operation.NewBaseReasonError("not BurnFact; %T", opp.Fact())
+	}
 
 	if err := fact.IsValid(nil); err != nil {
 		return nil, operation.NewBaseReasonError(err.Error())
@@ -248,7 +251,10 @@ func (opp *BurnProcessor) Process(
 	getState func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) error {
-	fact := opp.Fact().(BurnFact)
+	fact, ok := opp.Fact().(BurnFact)
+	if !ok {
+		return operation.NewBaseReasonError("not BurnFact; %T", opp.Fact())
+	}
 
 	var states []state.State
 
@@ -295,7 +301,10 @@ func (opp *BurnProcessor) Close() error {
 }
 
 func (opp *BurnProcessor) calculateItemsFee() (map[currency.CurrencyID][2]currency.Big, error) {
-	fact := opp.Fact().(BurnFact)
+	fact, ok := opp.Fact().(BurnFact)
+	if !ok {
+		return nil, errors.Errorf("not BurnFact; %T", opp.Fact())
+	}
 
 	items := make([]BurnItem, len(fact.items))
 	for i := range fact.items {

--- a/nft/collection/collection_policy_updater_process.go
+++ b/nft/collection/collection_policy_updater_process.go
@@ -36,7 +36,6 @@ type CollectionPolicyUpdaterProcessor struct {
 
 func NewCollectionPolicyUpdaterProcessor(cp *extensioncurrency.CurrencyPool) currency.GetNewProcessor {
 	return func(op state.Processor) (state.Processor, error) {
-
 		i, ok := op.(CollectionPolicyUpdater)
 		if !ok {
 			return nil, errors.Errorf("not CollectionPolicyUpdater; %T", op)
@@ -59,7 +58,10 @@ func (opp *CollectionPolicyUpdaterProcessor) PreProcess(
 	getState func(string) (state.State, bool, error),
 	_ func(valuehash.Hash, ...state.State) error,
 ) (state.Processor, error) {
-	fact := opp.Fact().(CollectionPolicyUpdaterFact)
+	fact, ok := opp.Fact().(CollectionPolicyUpdaterFact)
+	if !ok {
+		return nil, operation.NewBaseReasonError("not CollectionPolicyUpdaterFact; %T", opp.Fact())
+	}
 
 	if err := fact.IsValid(nil); err != nil {
 		return nil, operation.NewBaseReasonError(err.Error())
@@ -126,7 +128,10 @@ func (opp *CollectionPolicyUpdaterProcessor) Process(
 	_ func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) error {
-	fact := opp.Fact().(CollectionPolicyUpdaterFact)
+	fact, ok := opp.Fact().(CollectionPolicyUpdaterFact)
+	if !ok {
+		return operation.NewBaseReasonError("not CollectionPolicyUpdaterFact; %T", opp.Fact())
+	}
 
 	var states []state.State
 

--- a/nft/collection/collection_register_process.go
+++ b/nft/collection/collection_register_process.go
@@ -37,7 +37,6 @@ type CollectionRegisterProcessor struct {
 
 func NewCollectionRegisterProcessor(cp *extensioncurrency.CurrencyPool) currency.GetNewProcessor {
 	return func(op state.Processor) (state.Processor, error) {
-
 		i, ok := op.(CollectionRegister)
 		if !ok {
 			return nil, errors.Errorf("not CollectionRegister; %T", op)
@@ -61,7 +60,10 @@ func (opp *CollectionRegisterProcessor) PreProcess(
 	getState func(string) (state.State, bool, error),
 	_ func(valuehash.Hash, ...state.State) error,
 ) (state.Processor, error) {
-	fact := opp.Fact().(CollectionRegisterFact)
+	fact, ok := opp.Fact().(CollectionRegisterFact)
+	if !ok {
+		return nil, operation.NewBaseReasonError("not CollectionRegisterFact; %T", opp.Fact())
+	}
 
 	if err := fact.IsValid(nil); err != nil {
 		return nil, operation.NewBaseReasonError(err.Error())
@@ -151,7 +153,10 @@ func (opp *CollectionRegisterProcessor) Process(
 	_ func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) error {
-	fact := opp.Fact().(CollectionRegisterFact)
+	fact, ok := opp.Fact().(CollectionRegisterFact)
+	if !ok {
+		return operation.NewBaseReasonError("not CollectionRegisterFact; %T", opp.Fact())
+	}
 
 	var states []state.State
 

--- a/nft/collection/delegate.go
+++ b/nft/collection/delegate.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/currency"
 	"github.com/pkg/errors"
 	"github.com/spikeekips/mitum-currency/currency"
 	"github.com/spikeekips/mitum/base"
@@ -91,21 +92,19 @@ func (fact DelegateFact) IsValid(b []byte) error {
 		return err
 	}
 
-	founds := map[base.Address]struct{}{}
+	founds := map[extensioncurrency.ContractID]map[base.Address]struct{}{}
 	for i := range fact.items {
 		if err := isvalid.Check(nil, false, fact.items[i]); err != nil {
 			return err
 		}
 
 		agent := fact.items[i].Agent()
-		if err := agent.IsValid(nil); err != nil {
-			return err
-		}
+		collection := fact.items[i].Collection()
 
-		if _, found := founds[agent]; found {
-			return isvalid.InvalidError.Errorf("duplicated agent found; %q", agent)
+		if _, found := founds[collection][agent]; found {
+			return isvalid.InvalidError.Errorf("duplicated collection-agent pair found; %q-%q", collection, agent)
 		}
-		founds[agent] = struct{}{}
+		founds[collection][agent] = struct{}{}
 	}
 
 	return nil

--- a/nft/collection/delegate.go
+++ b/nft/collection/delegate.go
@@ -101,9 +101,12 @@ func (fact DelegateFact) IsValid(b []byte) error {
 		agent := fact.items[i].Agent()
 		collection := fact.items[i].Collection()
 
-		if _, found := founds[collection][agent]; found {
+		if addressMap, collectionFound := founds[collection]; !collectionFound {
+			founds[collection] = make(map[base.Address]struct{})
+		} else if _, addressFound := addressMap[agent]; addressFound {
 			return isvalid.InvalidError.Errorf("duplicated collection-agent pair found; %q-%q", collection, agent)
 		}
+
 		founds[collection][agent] = struct{}{}
 	}
 

--- a/nft/collection/delegate_process.go
+++ b/nft/collection/delegate_process.go
@@ -43,7 +43,6 @@ func (ipp *DelegateItemProcessor) PreProcess(
 	getState func(key string) (state.State, bool, error),
 	_ func(valuehash.Hash, ...state.State) error,
 ) error {
-
 	if err := ipp.item.IsValid(nil); err != nil {
 		return err
 	}
@@ -63,7 +62,6 @@ func (ipp *DelegateItemProcessor) Process(
 	_ func(key string) (state.State, bool, error),
 	_ func(valuehash.Hash, ...state.State) error,
 ) ([]state.State, error) {
-
 	switch ipp.item.Mode() {
 	case DelegateAllow:
 		if err := ipp.box.Append(ipp.item.Agent()); err != nil {
@@ -108,7 +106,7 @@ func NewDelegateProcessor(cp *extensioncurrency.CurrencyPool) currency.GetNewPro
 	return func(op state.Processor) (state.Processor, error) {
 		i, ok := op.(Delegate)
 		if !ok {
-			return nil, operation.NewBaseReasonError("not Delegate; %T", op)
+			return nil, errors.Errorf("not Delegate; %T", op)
 		}
 
 		opp := DelegateProcessorPool.Get().(*DelegateProcessor)
@@ -129,7 +127,10 @@ func (opp *DelegateProcessor) PreProcess(
 	getState func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) (state.Processor, error) {
-	fact := opp.Fact().(DelegateFact)
+	fact, ok := opp.Fact().(DelegateFact)
+	if !ok {
+		return nil, operation.NewBaseReasonError("not DelegateFact; %T", opp.Fact())
+	}
 
 	if err := fact.IsValid(nil); err != nil {
 		return nil, operation.NewBaseReasonError(err.Error())
@@ -212,7 +213,10 @@ func (opp *DelegateProcessor) Process(
 	getState func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) error {
-	fact := opp.Fact().(DelegateFact)
+	fact, ok := opp.Fact().(DelegateFact)
+	if !ok {
+		return operation.NewBaseReasonError("not DelegateFact; %T", opp.Fact())
+	}
 
 	var states []state.State
 
@@ -259,7 +263,10 @@ func (opp *DelegateProcessor) Close() error {
 }
 
 func (opp *DelegateProcessor) calculateItemsFee() (map[currency.CurrencyID][2]currency.Big, error) {
-	fact := opp.Fact().(DelegateFact)
+	fact, ok := opp.Fact().(DelegateFact)
+	if !ok {
+		return nil, errors.Errorf("not DelegateFact; %T", opp.Fact())
+	}
 
 	items := make([]DelegateItem, len(fact.items))
 	for i := range fact.items {

--- a/nft/collection/mint.go
+++ b/nft/collection/mint.go
@@ -64,7 +64,11 @@ func (fact MintFact) Bytes() []byte {
 }
 
 func (fact MintFact) IsValid(b []byte) error {
-	if err := fact.BaseHinter.IsValid(nil); err != nil {
+	if err := isvalid.Check(
+		nil, false,
+		fact.BaseHinter,
+		fact.h,
+		fact.sender); err != nil {
 		return err
 	}
 
@@ -82,11 +86,10 @@ func (fact MintFact) IsValid(b []byte) error {
 		return isvalid.InvalidError.Errorf("items over allowed; %d > %d", l, MaxMintItems)
 	}
 
-	if err := isvalid.Check(
-		nil, false,
-		fact.h,
-		fact.sender); err != nil {
-		return err
+	for i := range fact.items {
+		if err := fact.items[i].IsValid(nil); err != nil {
+			return err
+		}
 	}
 
 	if !fact.h.Equal(fact.GenerateHash()) {

--- a/nft/collection/mint_process.go
+++ b/nft/collection/mint_process.go
@@ -175,7 +175,10 @@ func (opp *MintProcessor) PreProcess(
 	getState func(string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) (state.Processor, error) {
-	fact := opp.Fact().(MintFact)
+	fact, ok := opp.Fact().(MintFact)
+	if !ok {
+		return nil, operation.NewBaseReasonError("not MintFact; %T", opp.Fact())
+	}
 
 	if err := fact.IsValid(nil); err != nil {
 		return nil, operation.NewBaseReasonError(err.Error())
@@ -297,7 +300,10 @@ func (opp *MintProcessor) Process(
 	getState func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) error {
-	fact := opp.Fact().(MintFact)
+	fact, ok := opp.Fact().(MintFact)
+	if !ok {
+		return operation.NewBaseReasonError("not MintFact; %T", opp.Fact())
+	}
 
 	var states []state.State
 
@@ -354,7 +360,10 @@ func (opp *MintProcessor) Close() error {
 }
 
 func (opp *MintProcessor) calculateItemsFee() (map[currency.CurrencyID][2]currency.Big, error) {
-	fact := opp.Fact().(MintFact)
+	fact, ok := opp.Fact().(MintFact)
+	if !ok {
+		return nil, errors.Errorf("not MintFact; %T", opp.Fact())
+	}
 
 	items := make([]MintItem, len(fact.items))
 	for i := range fact.items {

--- a/nft/collection/sign_item.go
+++ b/nft/collection/sign_item.go
@@ -61,7 +61,7 @@ func (it SignItem) Bytes() []byte {
 }
 
 func (it SignItem) IsValid([]byte) error {
-	return isvalid.Check(nil, false, it.BaseHinter, it.qualification, it.nft)
+	return isvalid.Check(nil, false, it.BaseHinter, it.qualification, it.nft, it.cid)
 }
 
 func (it SignItem) Qualification() Qualification {

--- a/nft/collection/sign_process.go
+++ b/nft/collection/sign_process.go
@@ -45,7 +45,6 @@ func (ipp *SignItemProcessor) PreProcess(
 	getState func(key string) (state.State, bool, error),
 	_ func(valuehash.Hash, ...state.State) error,
 ) error {
-
 	if err := ipp.item.IsValid(nil); err != nil {
 		return err
 	}
@@ -176,7 +175,10 @@ func (opp *SignProcessor) PreProcess(
 	getState func(string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) (state.Processor, error) {
-	fact := opp.Fact().(SignFact)
+	fact, ok := opp.Fact().(SignFact)
+	if !ok {
+		return nil, operation.NewBaseReasonError("not SignFact; %T", opp.Fact())
+	}
 
 	if err := fact.IsValid(nil); err != nil {
 		return nil, operation.NewBaseReasonError(err.Error())
@@ -234,7 +236,10 @@ func (opp *SignProcessor) Process(
 	getState func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) error {
-	fact := opp.Fact().(SignFact)
+	fact, ok := opp.Fact().(SignFact)
+	if !ok {
+		return operation.NewBaseReasonError("not SignFact; %T", opp.Fact())
+	}
 
 	var states []state.State
 
@@ -271,7 +276,10 @@ func (opp *SignProcessor) Close() error {
 }
 
 func (opp *SignProcessor) calculateItemsFee() (map[currency.CurrencyID][2]currency.Big, error) {
-	fact := opp.Fact().(SignFact)
+	fact, ok := opp.Fact().(SignFact)
+	if !ok {
+		return nil, errors.Errorf("not SignFact; %T", opp.Fact())
+	}
 
 	items := make([]SignItem, len(fact.items))
 	for i := range fact.items {

--- a/nft/collection/transfer_process.go
+++ b/nft/collection/transfer_process.go
@@ -45,7 +45,6 @@ func (ipp *TransferItemProcessor) PreProcess(
 	getState func(key string) (state.State, bool, error),
 	_ func(valuehash.Hash, ...state.State) error,
 ) error {
-
 	if err := ipp.item.IsValid(nil); err != nil {
 		return err
 	}
@@ -167,7 +166,10 @@ func (opp *TransferProcessor) PreProcess(
 	getState func(string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) (state.Processor, error) {
-	fact := opp.Fact().(TransferFact)
+	fact, ok := opp.Fact().(TransferFact)
+	if !ok {
+		return nil, operation.NewBaseReasonError("not TransferFact; %T", opp.Fact())
+	}
 
 	if err := fact.IsValid(nil); err != nil {
 		return nil, operation.NewBaseReasonError(err.Error())
@@ -225,7 +227,10 @@ func (opp *TransferProcessor) Process(
 	getState func(key string) (state.State, bool, error),
 	setState func(valuehash.Hash, ...state.State) error,
 ) error {
-	fact := opp.Fact().(TransferFact)
+	fact, ok := opp.Fact().(TransferFact)
+	if !ok {
+		return operation.NewBaseReasonError("not TransferFact; %T", opp.Fact())
+	}
 
 	var states []state.State
 
@@ -262,7 +267,10 @@ func (opp *TransferProcessor) Close() error {
 }
 
 func (opp *TransferProcessor) calculateItemsFee() (map[currency.CurrencyID][2]currency.Big, error) {
-	fact := opp.Fact().(TransferFact)
+	fact, ok := opp.Fact().(TransferFact)
+	if !ok {
+		return nil, errors.Errorf("not TransferFact; %T", opp.Fact())
+	}
 
 	items := make([]TransferItem, len(fact.items))
 	for i := range fact.items {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix

* **What is the current behavior?** (You can also link to an open issue here)
Not validating each mint item
Not validation currency in sign item
Not checking collection-agent duplication in delegate item; now, wrong validation for duplicate agent

* **What is the new behavior (if this is a feature change)?**
Validating each mint item in `IsValid` of mint fact
Validating currency in `IsValid` of sign item
Checking collection-agent duplication in delegate item; just duplicate agent is available

* **Other information**:
Added code for error handling when typecasting of 'fact' to each operation processor.
The panic issue caused by mismatch between operation hint and fact type is now patched.