### PR TITLE
Limiting collection/nft uri and nft hash lengths

### DIFF
--- a/nft/collection/policy.go
+++ b/nft/collection/policy.go
@@ -90,7 +90,8 @@ func (policy CollectionPolicy) Bytes() []byte {
 func (policy CollectionPolicy) IsValid([]byte) error {
 	if err := isvalid.Check(nil, false,
 		policy.name,
-		policy.royalty); err != nil {
+		policy.royalty,
+		policy.uri); err != nil {
 		return err
 	}
 

--- a/nft/design.go
+++ b/nft/design.go
@@ -2,6 +2,7 @@ package nft
 
 import (
 	"net/url"
+	"strings"
 
 	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/currency"
 	"github.com/spikeekips/mitum/base"
@@ -30,6 +31,8 @@ func (pp PaymentParameter) IsValid([]byte) error {
 	return nil
 }
 
+var MaxURILength = 1000
+
 type URI string
 
 func (uri URI) Bytes() []byte {
@@ -44,6 +47,15 @@ func (uri URI) IsValid([]byte) error {
 	if _, err := url.Parse(string(uri)); err != nil {
 		return err
 	}
+
+	if l := len(uri); l > 1000 {
+		return isvalid.InvalidError.Errorf("invalid length of uri; %d > %d", l, MaxURILength)
+	}
+
+	if uri != "" && strings.TrimSpace(string(uri)) == "" {
+		return isvalid.InvalidError.Errorf("uri with only spaces")
+	}
+
 	return nil
 }
 

--- a/nft/nft.go
+++ b/nft/nft.go
@@ -1,12 +1,16 @@
 package nft
 
 import (
+	"strings"
+
 	"github.com/spikeekips/mitum/base"
 	"github.com/spikeekips/mitum/util"
 	"github.com/spikeekips/mitum/util/hint"
 	"github.com/spikeekips/mitum/util/isvalid"
 	"github.com/spikeekips/mitum/util/valuehash"
 )
+
+var MaxNFTHashLength = 1024
 
 type NFTHash string
 
@@ -19,6 +23,14 @@ func (hs NFTHash) String() string {
 }
 
 func (hs NFTHash) IsValid([]byte) error {
+	if l := len(hs); l > MaxNFTHashLength {
+		return isvalid.InvalidError.Errorf("invalid length of nft hash; %d > %d", l, MaxNFTHashLength)
+	}
+
+	if hs != "" && strings.TrimSpace(string(hs)) == "" {
+		return isvalid.InvalidError.Errorf("nft hash with only spaces")
+	}
+
 	return nil
 }
 

--- a/nft/nft_id.go
+++ b/nft/nft_id.go
@@ -89,6 +89,11 @@ func (nid NFTID) IsValid([]byte) error {
 	if nid.idx > uint64(MaxNFTIdx) {
 		return isvalid.InvalidError.Errorf("nid idx over max; %d > %d", nid.idx, MaxNFTIdx)
 	}
+
+	if nid.idx == 0 {
+		return isvalid.InvalidError.Errorf("nid idx must be over zero; %q", nid)
+	}
+
 	if err := nid.collection.IsValid(nil); err != nil {
 		return err
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore

* **What is the current behavior?** (You can also link to an open issue here)
1. no limitation for collection/nft uri and nft hash lengths
2. allowing zero nft-id idx
3. no validation for collection uri in collection policy

* **What is the new behavior (if this is a feature change)?**
1. limiting collection/nft uri and nft hash lengths (1000, 1024)
2. disallowing zero nft-id idx
3. validating collection uri in collection policy

* **Other information**: